### PR TITLE
Add support for passwords URL encoded passwords.

### DIFF
--- a/lib/postgres_pool.dart
+++ b/lib/postgres_pool.dart
@@ -43,8 +43,8 @@ class PgEndpoint {
   factory PgEndpoint.parse(url) {
     final uri = url is Uri ? url : Uri.parse(url as String);
     final userInfoParts = uri.userInfo.split(':');
-    final username = userInfoParts.length == 2 ? userInfoParts[0] : null;
-    final password = userInfoParts.length == 2 ? userInfoParts[1] : null;
+    final username = userInfoParts.length == 2 ? Uri.decodeComponent(userInfoParts[0]) : null;
+    final password = userInfoParts.length == 2 ? Uri.decodeComponent(userInfoParts[1]) : null;
     final isUnixSocketParam = uri.queryParameters['is-unix-socket'];
     return PgEndpoint(
       host: uri.host,


### PR DESCRIPTION
Passwords with symbols such as / or @ need to be URL Encoded so they can be parsed correctly.
This change ensures the proper decoding.